### PR TITLE
adds call to configureRoutes() method

### DIFF
--- a/common/common.routes.config.ts
+++ b/common/common.routes.config.ts
@@ -7,6 +7,7 @@ export abstract class CommonRoutesConfig {
   constructor(app: express.Application, name: string) {
     this.app = app;
     this.name = name;
+    this.configureRoutes();
   }
 
   abstract configureRoutes(): express.Application;


### PR DESCRIPTION
necessary to enable routes beyond just `/` (currently only `UsersRoutes`)